### PR TITLE
Fix `tokensOf`, add printer check to integration test

### DIFF
--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -11,7 +11,7 @@ import Data.Foldable (for_)
 import Data.FoldableWithIndex (forWithIndex_)
 import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
-import Data.Newtype (un, unwrap)
+import Data.Newtype (unwrap)
 import Data.Number.Format as NF
 import Data.String as Str
 import Data.String.CodeUnits as String
@@ -39,9 +39,6 @@ import PureScript.CST.Lexer (lex)
 import PureScript.CST.Parser (Recovered)
 import PureScript.CST.Parser as Parser
 import PureScript.CST.Parser.Monad (PositionedError, runParser)
-import PureScript.CST.Print as Print
-import PureScript.CST.Range (tokensOf)
-import PureScript.CST.Range.TokenList as TokenList
 import PureScript.CST.TokenStream (TokenStream)
 import PureScript.CST.Types (Module)
 

--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -132,7 +132,6 @@ main = runAff_ (either throwException mempty) do
           ]
       Console.error message
 
-
 -- TODO: Upgrade packages ref to 0.14 package set
 defaultSpagoDhall :: String
 defaultSpagoDhall = Array.intercalate "\n"

--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -111,7 +111,7 @@ main = runAff_ (either throwException mempty) do
     printerSucceeded = Array.filter (_.printerMatches >>> eq (Just true)) partition.right
 
     printerSuccessMessage = Array.intercalate " "
-      [ "Successfully printer"
+      [ "Successfully printed"
       , show (Array.length printerSucceeded)
       , "of"
       , show (Array.length partition.right)

--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -33,6 +33,7 @@ import Node.Encoding (Encoding(..))
 import Node.FS.Aff (readTextFile, readdir, stat, writeTextFile)
 import Node.FS.Stats as FS
 import Node.Path (FilePath)
+import PureScript.CST (printModule)
 import PureScript.CST.Errors (printParseError)
 import PureScript.CST.Lexer (lex)
 import PureScript.CST.Parser (Recovered)
@@ -176,11 +177,7 @@ parseModuleFromFile path = do
 
     printerMatches = case parsed of
       Right (Tuple mod _) -> do
-        let
-          printed =
-            foldMap Print.printSourceToken (TokenList.toArray (tokensOf mod))
-              <> foldMap (Print.printComment Print.printLineFeed) (unwrap (unwrap mod).body).trailingComments
-        pure $ contents == printed
+        pure $ contents == printModule mod
       _ -> Nothing
 
   pure

--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -108,6 +108,19 @@ main = runAff_ (either throwException mempty) do
   liftEffect $ Console.log $ displayDurationStats (getDurationStats partition.right) "Success Case"
 
   let
+    printerSucceeded = Array.filter (_.printerMatches >>> eq (Just true)) partition.right
+
+    printerSuccessMessage = Array.intercalate " "
+      [ "Successfully printer"
+      , show (Array.length printerSucceeded)
+      , "of"
+      , show (Array.length partition.right)
+      , "successully parsed modules."
+      ]
+
+  liftEffect $ Console.log printerSuccessMessage
+
+  let
     printerFailed = Array.filter (_.printerMatches >>> eq (Just false)) partition.right
 
     printerFailedMessage = Array.intercalate " "

--- a/integration/Main.purs
+++ b/integration/Main.purs
@@ -11,7 +11,7 @@ import Data.Foldable (for_)
 import Data.FoldableWithIndex (forWithIndex_)
 import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
-import Data.Newtype (unwrap)
+import Data.Newtype (un)
 import Data.Number.Format as NF
 import Data.String as Str
 import Data.String.CodeUnits as String

--- a/src/PureScript/CST.purs
+++ b/src/PureScript/CST.purs
@@ -8,6 +8,7 @@ module PureScript.CST
   , parseExpr
   , parseType
   , parseBinder
+  , printModule
   ) where
 
 import Prelude
@@ -15,13 +16,18 @@ import Prelude
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Either (Either(..))
+import Data.Foldable (foldMap)
 import Data.Lazy as Z
 import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
 import Data.Tuple (Tuple(..))
 import PureScript.CST.Lexer (lex)
 import PureScript.CST.Parser (Recovered, parseModuleBody, parseModuleHeader)
 import PureScript.CST.Parser as Parser
 import PureScript.CST.Parser.Monad (Parser, ParserResult(..), PositionedError, fromParserResult, initialParserState, runParser, runParser')
+import PureScript.CST.Print as Print
+import PureScript.CST.Range (class TokensOf, tokensOf)
+import PureScript.CST.Range.TokenList as TokenList
 import PureScript.CST.Types (Binder, Declaration, Expr, ImportDecl, Module(..), ModuleHeader, Type)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -84,3 +90,8 @@ parsePartialModule src =
       Right $ Tuple res state.errors
     ParseFail error position _ _ ->
       Left { error, position }
+
+printModule :: forall e. TokensOf e => Module e -> String
+printModule mod =
+  foldMap Print.printSourceToken (TokenList.toArray (tokensOf mod))
+    <> foldMap (Print.printComment Print.printLineFeed) (unwrap (unwrap mod).body).trailingComments

--- a/src/PureScript/CST/Range.purs
+++ b/src/PureScript/CST/Range.purs
@@ -117,8 +117,8 @@ instance rangeOfLabeled :: (RangeOf a, RangeOf b) => RangeOf (Labeled a b) where
     }
 
 instance tokensOfLabeled :: (TokensOf a, TokensOf b) => TokensOf (Labeled a b) where
-  tokensOf (Labeled { label, value }) =
-    tokensOf label <> tokensOf value
+  tokensOf (Labeled { label, separator, value }) =
+    tokensOf label <> singleton separator <> tokensOf value
 
 instance rangeOfOneOrDelimited :: RangeOf a => RangeOf (OneOrDelimited a) where
   rangeOf = case _ of
@@ -801,7 +801,7 @@ instance tokensOfExpr :: TokensOf e => TokensOf (Expr e) where
     ExprRecordUpdate expr upds ->
       tokensOf expr <> defer \_ -> tokensOf upds
     ExprApp expr exprs ->
-      tokensOf expr <> defer \_ -> tokensOf expr
+      tokensOf expr <> defer \_ -> tokensOf exprs
     ExprLambda { symbol, binders, arrow, body } ->
       cons symbol $ defer \_ ->
         tokensOf binders

--- a/src/PureScript/CST/Types.purs
+++ b/src/PureScript/CST/Types.purs
@@ -188,6 +188,8 @@ newtype Module e = Module
   , body :: ModuleBody e
   }
 
+derive instance newtypeModule :: Newtype (Module e) _
+
 newtype ModuleHeader e = ModuleHeader
   { keyword :: SourceToken
   , name :: Name ModuleName


### PR DESCRIPTION
This intends to close #10 

Fixes some missing tokens in `tokensOf`, specifically for `Labeled` and `Expr`.

Adds a step to the integration test to make sure that the original file and the printed CST match for every module in the package set.

Note: In #10 I was using `foldMap Print.printSourceToken $ TokenList.toArray $ tokensOf mod` to print the modules. This is not completely correct, as it won't print trailing comments or whitespace (there are very commonly trailing newlines in modules). The correct way to make `parse >>> print === id` is manually print the `ModuleBody` `trailingComments`, like this:

```
foldMap Print.printSourceToken (TokenList.toArray (tokensOf mod))
  <> foldMap (Print.printComment Print.printLineFeed) (unwrap (unwrap mod).body).trailingComments
```