### PR TITLE
Rename TypeArr to TypeArrow

### DIFF
--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -411,7 +411,7 @@ parseType1 = defer \_ -> do
 parseType2 :: Parser (Recovered Type)
 parseType2 = defer \_ -> do
   ty <- parseType3
-  TypeArr ty <$> tokRightArrow <*> parseType1
+  TypeArrow ty <$> tokRightArrow <*> parseType1
     <|> TypeConstrained ty <$> tokRightFatArrow <*> parseType1
     <|> pure ty
 
@@ -446,7 +446,7 @@ parseTypeAtom = defer \_ ->
     <|> TypeOpName <$> parseQualifiedSymbol
     <|> TypeHole <$> parseHole
     <|> TypeWildcard <$> tokUnderscore
-    <|> TypeArrName <$> tokSymbolArrow
+    <|> TypeArrowName <$> tokSymbolArrow
 
 parseTypeParens :: Parser (Recovered Type)
 parseTypeParens = do

--- a/src/PureScript/CST/Range.purs
+++ b/src/PureScript/CST/Range.purs
@@ -164,11 +164,11 @@ instance rangeOfType :: RangeOf e => RangeOf (Type e) where
       }
     TypeOpName n ->
       rangeOf n
-    TypeArr ty1 _ ty2 ->
+    TypeArrow ty1 _ ty2 ->
       { start: (rangeOf ty1).start
       , end: (rangeOf ty2).end
       }
-    TypeArrName t ->
+    TypeArrowName t ->
       t.range
     TypeConstrained ty1 _ ty2 ->
       { start: (rangeOf ty1).start
@@ -215,10 +215,10 @@ instance tokensOfType :: TokensOf e => TokensOf (Type e) where
         <> defer \_ -> foldMap (\(Tuple op arg) -> tokensOf op <> tokensOf arg) ops
     TypeOpName n ->
       tokensOf n
-    TypeArr ty1 t ty2 ->
+    TypeArrow ty1 t ty2 ->
       tokensOf ty1
         <> defer \_ -> singleton t <> tokensOf ty2
-    TypeArrName t ->
+    TypeArrowName t ->
       singleton t
     TypeConstrained ty1 t ty2 ->
       tokensOf ty1

--- a/src/PureScript/CST/Traversal.purs
+++ b/src/PureScript/CST/Traversal.purs
@@ -281,7 +281,7 @@ traverseType k = case _ of
   TypeKinded typ1 tok typ2 -> TypeKinded <$> k.onType typ1 <@> tok <*> k.onType typ2
   TypeApp typ args -> TypeApp <$> k.onType typ <*> traverse k.onType args
   TypeOp typ ops -> TypeOp <$> k.onType typ <*> traverse (traverse k.onType) ops
-  TypeArr typ1 tok typ2 -> TypeArr <$> k.onType typ1 <@> tok <*> k.onType typ2
+  TypeArrow typ1 tok typ2 -> TypeArrow <$> k.onType typ1 <@> tok <*> k.onType typ2
   TypeConstrained typ1 tok typ2 -> TypeConstrained <$> k.onType typ1 <@> tok <*> k.onType typ2
   TypeParens wrapped -> TypeParens <$> traverseWrapped k.onType wrapped
   TypeUnaryRow tok typ -> TypeUnaryRow tok <$> k.onType typ

--- a/src/PureScript/CST/Types.purs
+++ b/src/PureScript/CST/Types.purs
@@ -165,8 +165,8 @@ data Type e
   | TypeApp (Type e) (NonEmptyArray (Type e))
   | TypeOp (Type e) (NonEmptyArray (Tuple (QualifiedName Operator) (Type e)))
   | TypeOpName (QualifiedName Operator)
-  | TypeArr (Type e) SourceToken (Type e)
-  | TypeArrName SourceToken
+  | TypeArrow (Type e) SourceToken (Type e)
+  | TypeArrowName SourceToken
   | TypeConstrained (Type e) SourceToken (Type e)
   | TypeParens (Wrapped (Type e))
   | TypeUnaryRow SourceToken (Type e)


### PR DESCRIPTION
I've stumbled on the `TypeArr` name a couple of times; I reflexively think 'array' because 'arr' is such a common abbreviation for it. `TypeArrow` is more obvious without being much longer, and I'd suggest we consider it to replace `TypeArr`.