### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        uses: purescript-contrib/setup-purescript@main
+
+      - name: Cache PureScript dependencies
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
+          path: |
+            .spago
+            output
+
+      - name: Build source
+        run: spago build --purs-args '--censor-lib --strict'
+
+      - name: Parse package sets
+        run: npm run parse-package-set
+
+      - name: Run file benchmark
+        run: npm run bench-file test/Main.purs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        uses: purescript-contrib/setup-purescript@main
+      
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.14.0"
+          spago: "0.19.1"
+          psa: "0.8.2"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0"
-          spago: "0.19.1"
+          purescript: "0.13.8"
+          spago: "0.19.0"
           psa: "0.8.2"
 
       - name: Cache PureScript dependencies


### PR DESCRIPTION
This adds a simple CI check to ensure the source builds and the two included scripts (`bench-file` and `parse-package-set`) run successfully.