### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.5"
-          spago: "0.20.3"
+          purescript: "0.15.0"
+          spago: "0.20.9"
           psa: "0.8.2"
           purs-tidy: "latest"
 

--- a/bench/bench.dhall
+++ b/bench/bench.dhall
@@ -29,7 +29,6 @@ in conf // {
     , "ordered-collections"
     , "partial"
     , "prelude"
-    , "psci-support"
     , "st"
     , "strings"
     , "strings"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "parse-package-set": "spago -x parse-package-set/parse-package-set.dhall run",
-    "bench-file": "spago -x bench/bench.dhall build && node --expose-gc -e \"require('./output/BenchFile/index.js').main()\"",
+    "bench-file": "spago -x bench/bench.dhall build && node --expose-gc --input-type=\"module\" -e \"import { main } from './output/BenchFile/index.js';main()\"",
     "format": "purs-tidy format-in-place src test bench parse-package-set",
     "check": "purs-tidy check src test bench parse-package-set"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "check": "purs-tidy check src test bench parse-package-set"
   },
   "devDependencies": {
-    "purescript": "^0.14.0",
-    "purs-tidy": "^0.3.0",
-    "spago": "^0.19.1"
+    "purescript": "^0.15.0",
+    "purs-tidy": "^0.8.0",
+    "spago": "^0.20.9"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210304/packages.dhall sha256:c88151fe7c05f05290224c9c1ae4a22905060424fb01071b691d3fe2e5bad4ca
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220507/packages.dhall
+        sha256:cf54330f3bc1b25a093b69bff8489180c954b43668c81288901a2ec29a08cc64
 
 in  upstream

--- a/parse-package-set/Main.js
+++ b/parse-package-set/Main.js
@@ -1,17 +1,22 @@
-const fs = require("fs");
-const os = require("os");
-const path = require("path");
-const process = require("process");
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { hrtime } from "process";
 
-exports.tmpdir = (prefix) => () =>
-  fs.mkdtempSync(path.join(os.tmpdir(), prefix), "utf-8");
+const tmpdirImpl = function (prefix) {
+  return () => mkdtempSync(join(tmpdir(), prefix), "utf-8");
+};
+export { tmpdirImpl as tmpdir };
 
-exports.hrtime = () => {
-  const t = process.hrtime()
+const hrtimeImpl = function () {
+  const t = hrtime();
   return { seconds: t[0], nanos: t[1] };
 };
+export { hrtimeImpl as hrtime };
 
-exports.hrtimeDiff = (old) => () => {
-  const t = process.hrtime([old.seconds, old.nanos]);
-  return { seconds: t[0], nanos: t[1] };
-};
+export function hrtimeDiff(old) {
+  return () => {
+    const t = hrtime([old.seconds, old.nanos]);
+    return { seconds: t[0], nanos: t[1] };
+  };
+}

--- a/parse-package-set/Main.purs
+++ b/parse-package-set/Main.purs
@@ -154,12 +154,11 @@ main = runAff_ (either throwException mempty) do
       [ "Error: cycle detected in module graph"
       ]
 
--- TODO: Upgrade packages ref to 0.14 package set
 defaultSpagoDhall :: String
 defaultSpagoDhall = Array.intercalate "\n"
   [ "{ name = \"test-parser\""
   , ", dependencies = [] : List Text"
-  , ", packages = https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210304/packages.dhall sha256:c88151fe7c05f05290224c9c1ae4a22905060424fb01071b691d3fe2e5bad4ca"
+  , ", packages = https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220507/packages.dhall sha256:cf54330f3bc1b25a093b69bff8489180c954b43668c81288901a2ec29a08cc64"
   , ", sources = [] : List Text"
   , "}"
   ]

--- a/parse-package-set/parse-package-set.dhall
+++ b/parse-package-set/parse-package-set.dhall
@@ -35,7 +35,6 @@ in conf // {
     , "parallel"
     , "partial"
     , "prelude"
-    , "psci-support"
     , "st"
     , "strings"
     , "transformers"

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,4 +1,6 @@
 { name = "language-cst-parser"
+, license = "MIT"
+, repository = "https://github.com/natefaubion/purescript-language-cst-parser.git"
 , dependencies =
   [ "arrays"
   , "console"

--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -258,7 +258,7 @@ parseDeclClassSignature keyword = do
 
 parseDeclClass1 :: SourceToken -> Parser (Recovered Declaration)
 parseDeclClass1 keyword = do
-  super <- optional $ try $ Tuple <$> parseClassConstraints parseType4 <*> tokLeftFatArrow
+  super <- optional $ try $ Tuple <$> parseClassConstraints parseType5 <*> tokLeftFatArrow
   name <- parseProper
   vars <- many parseTypeVarBinding
   fundeps <- optional $ Tuple <$> tokPipe <*> separated tokComma parseFundep
@@ -424,6 +424,10 @@ parseType3 = defer \_ -> do
 
 parseType4 :: Parser (Recovered Type)
 parseType4 = defer \_ -> do
+  parseTypeNegative <|> parseType5
+
+parseType5 :: Parser (Recovered Type)
+parseType5 = defer \_ -> do
   ty <- parseTypeAtom
   args <- many parseTypeAtom
   pure case NonEmptyArray.fromArray args of
@@ -451,6 +455,11 @@ parseTypeParens = do
     <|> parseKindedVar open
     <|> parseTypeParen open
     <|> parseEmptyRow open
+
+parseTypeNegative :: Parser (Recovered Type)
+parseTypeNegative = do
+  negative <- tokKeyOperator "-"
+  uncurry (TypeInt (Just negative)) <$> parseInt
 
 parseRowParen :: SourceToken -> Parser (Recovered Type)
 parseRowParen open = do

--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -258,7 +258,7 @@ parseDeclClassSignature keyword = do
 
 parseDeclClass1 :: SourceToken -> Parser (Recovered Declaration)
 parseDeclClass1 keyword = do
-  super <- optional $ try $ Tuple <$> parseClassConstraints parseType5 <*> tokLeftFatArrow
+  super <- optional $ try $ Tuple <$> parseClassConstraints parseType4 <*> tokLeftFatArrow
   name <- parseProper
   vars <- many parseTypeVarBinding
   fundeps <- optional $ Tuple <$> tokPipe <*> separated tokComma parseFundep
@@ -423,11 +423,7 @@ parseType3 = defer \_ -> do
     Just os -> TypeOp ty os
 
 parseType4 :: Parser (Recovered Type)
-parseType4 = defer \_ ->
-  parseType5
-
-parseType5 :: Parser (Recovered Type)
-parseType5 = defer \_ -> do
+parseType4 = defer \_ -> do
   ty <- parseTypeAtom
   args <- many parseTypeAtom
   pure case NonEmptyArray.fromArray args of

--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -435,7 +435,7 @@ parseTypeAtom = defer \_ ->
   TypeVar <$> parseIdent
     <|> TypeConstructor <$> parseQualifiedProper
     <|> uncurry TypeString <$> parseString
-    <|> uncurry TypeInt <$> parseInt
+    <|> uncurry (TypeInt Nothing) <$> parseInt
     <|> parseTypeParens
     <|> TypeRecord <$> braces parseRow
     <|> TypeOpName <$> parseQualifiedSymbol

--- a/src/PureScript/CST/Range.purs
+++ b/src/PureScript/CST/Range.purs
@@ -143,8 +143,14 @@ instance rangeOfType :: RangeOf e => RangeOf (Type e) where
       rangeOf n
     TypeString t _ ->
       t.range
-    TypeInt t _ ->
-      t.range
+    TypeInt neg t _ ->
+      case neg of
+        Nothing ->
+          t.range
+        Just n ->
+          { start: n.range.start
+          , end: t.range.end
+          }
     TypeRow w ->
       rangeOf w
     TypeRecord w ->
@@ -194,8 +200,8 @@ instance tokensOfType :: TokensOf e => TokensOf (Type e) where
       tokensOf n
     TypeString t _ ->
       singleton t
-    TypeInt t _ ->
-      singleton t
+    TypeInt neg t _ ->
+      foldMap singleton neg <> singleton t
     TypeRow w ->
       tokensOf w
     TypeRecord w ->

--- a/src/PureScript/CST/Types.purs
+++ b/src/PureScript/CST/Types.purs
@@ -166,7 +166,7 @@ data Type e
   | TypeWildcard SourceToken
   | TypeHole (Name Ident)
   | TypeString SourceToken String
-  | TypeInt SourceToken IntValue
+  | TypeInt (Maybe SourceToken) SourceToken IntValue
   | TypeRow (Wrapped (Row e))
   | TypeRecord (Wrapped (Row e))
   | TypeForall SourceToken (NonEmptyArray (TypeVarBinding e)) SourceToken (Type e)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -144,3 +144,18 @@ main = do
         true
       _ ->
         false
+
+  assertParse "Negative type-level integers"
+    """
+    cons ∷
+      ∀ len len_plus_1 elem.
+      Add 1 len len_plus_1 ⇒
+      Compare len (-1) GT =>
+      elem → Vect len elem → Vect len_plus_1 elem
+    cons elem (Vect arr) = Vect (A.cons elem arr)
+    """
+    case _ of
+      (ParseSucceeded _ :: RecoveredParserResult Declaration) ->
+        true
+      _ ->
+        false

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,13 +10,9 @@ import Data.String (Pattern(..))
 import Data.String as String
 import Data.String.CodeUnits as SCU
 import Effect (Effect)
-import Effect.Class.Console (log)
 import Effect.Class.Console as Console
-import Effect.Unsafe (unsafePerformEffect)
 import Node.Process as Process
-import Partial.Unsafe (unsafeCrashWith)
 import PureScript.CST (RecoveredParserResult(..), parseBinder, parseDecl, parseExpr, parseModule, parseType)
-import PureScript.CST.Errors (printParseError)
 import PureScript.CST.Types (Binder, Declaration(..), DoStatement(..), Expr(..), Label(..), LetBinding(..), Module(..), ModuleBody(..), Name(..), RecordLabeled(..), Separated(..), Token(..), Type, Wrapped(..))
 
 class ParseFor f where
@@ -163,15 +159,5 @@ main = do
     case _ of
       (ParseSucceeded _ :: RecoveredParserResult Declaration) ->
         true
-      (ParseFailed err) -> do
-        let
-          _ =
-            unsafePerformEffect do
-              let
-                print { position, error } =
-                  "[" <> show (position.line + 1) <> ":" <> show (position.column + 1) <> "] " <> printParseError error
-              log (print err)
-
-        false
       _ ->
         false


### PR DESCRIPTION
This PR updates the library to use PureScript 0.15 and to parse the PureScript 0.15 package set. Since this library isn't usable by Bower users in the first place and there were no code changes, I'm not sure what you want to do about the next version number @natefaubion.

Also fixes #41.