### PR TITLE
Add support for pulp & bower

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,8 @@ jobs:
 
       - name: Run file benchmark
         run: npm run bench-file src/PureScript/CST/Parser.purs
+
+      - name: Verify pulp & bower
+        run: |
+          npx bower@1.8.14 install --production
+          npx pulp@16.0.0 build

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,36 @@
+{
+  "name": "purescript-language-cst-parser",
+  "license": ["MIT"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/natefaubion/purescript-language-cst-parser.git"
+  },
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
+  "dependencies": {
+    "purescript-arrays": "^v7.0.0",
+    "purescript-const": "^v6.0.0",
+    "purescript-control": "^v6.0.0",
+    "purescript-either": "^v6.0.0",
+    "purescript-foldable-traversable": "^v6.0.0",
+    "purescript-free": "^v7.0.0",
+    "purescript-functions": "^v6.0.0",
+    "purescript-functors": "^v5.0.0",
+    "purescript-identity": "^v6.0.0",
+    "purescript-integers": "^v6.0.0",
+    "purescript-lazy": "^v6.0.0",
+    "purescript-lists": "^v7.0.0",
+    "purescript-maybe": "^v6.0.0",
+    "purescript-newtype": "^v5.0.0",
+    "purescript-numbers": "^v9.0.0",
+    "purescript-ordered-collections": "^v3.0.0",
+    "purescript-partial": "^v4.0.0",
+    "purescript-prelude": "^v6.0.0",
+    "purescript-st": "^v6.0.0",
+    "purescript-strings": "^v6.0.0",
+    "purescript-transformers": "^v6.0.0",
+    "purescript-tuples": "^v7.0.0",
+    "purescript-typelevel-prelude": "^v7.0.0",
+    "purescript-unfoldable": "^v6.0.0",
+    "purescript-unsafe-coerce": "^v6.0.0"
+  }
+}


### PR DESCRIPTION
This PR adds a `bower.json` file which can be used to publish this library's documentation to Pursuit. It also adds a step in CI that verifies that the library compiles using Pulp and the provided Bowerfile.

I understand if you think this is too much of a hassle to keep up, in which case feel free to close this.