### PR TITLE
Fix escaped Unicode hex literals parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.15.0"
+          purescript: "0.15.8"
           spago: "0.20.9"
           psa: "0.8.2"
           purs-tidy: "latest"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ By adding your name to the list below, you agree to license your contributions u
 | [@rintcius](https://github.com/rintcius) | Rintcius Blok
 | [@i-am-the-slime](https://github.com/i-am-the-slime) | Mark Eibes
 | [@monoidmusician](https://github.com/MonoidMusician) | Verity Scheel
+| [@turlando](https://github.com/turlando) | Tancredi Orlando

--- a/bench/bench.dhall
+++ b/bench/bench.dhall
@@ -10,6 +10,7 @@ in conf // {
     , "control"
     , "effect"
     , "either"
+    , "enums"
     , "foldable-traversable"
     , "free"
     , "functions"

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220507/packages.dhall
-        sha256:cf54330f3bc1b25a093b69bff8489180c954b43668c81288901a2ec29a08cc64
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230401/packages.dhall
+        sha256:d385eeee6ca160c32d7389a1f4f4ee6a05aff95e81373cdc50670b436efa1060
 
 in  upstream

--- a/parse-package-set/Main.purs
+++ b/parse-package-set/Main.purs
@@ -158,7 +158,7 @@ defaultSpagoDhall :: String
 defaultSpagoDhall = Array.intercalate "\n"
   [ "{ name = \"test-parser\""
   , ", dependencies = [] : List Text"
-  , ", packages = https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220507/packages.dhall sha256:cf54330f3bc1b25a093b69bff8489180c954b43668c81288901a2ec29a08cc64"
+  , ", packages = https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230401/packages.dhall sha256:d385eeee6ca160c32d7389a1f4f4ee6a05aff95e81373cdc50670b436efa1060"
   , ", sources = [] : List Text"
   , "}"
   ]

--- a/parse-package-set/parse-package-set.dhall
+++ b/parse-package-set/parse-package-set.dhall
@@ -12,6 +12,7 @@ in conf // {
     , "datetime"
     , "effect"
     , "either"
+    , "enums"
     , "exceptions"
     , "filterable"
     , "foldable-traversable"

--- a/spago.dhall
+++ b/spago.dhall
@@ -8,6 +8,7 @@
   , "control"
   , "effect"
   , "either"
+  , "enums"
   , "foldable-traversable"
   , "free"
   , "functions"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -232,3 +232,23 @@ main = do
         true
       _ ->
         false
+
+  assertParse "String with Unicode astral code point hex literal"
+    """
+    "\x10ffff"
+    """
+    case _ of
+      ParseSucceeded (ExprString _ _) ->
+        true
+      _ ->
+        false
+
+  assertParse "Unicode astral code point Char hex literal"
+    """
+    '\x10ffff'
+    """
+    case _ of
+      (ParseFailed _ :: RecoveredParserResult Expr) ->
+        true
+      _ ->
+        false


### PR DESCRIPTION
The Char type represents a UTF-16 code unit, while String can contain
any UTF-8 code unit. The same logic for escaping Unicode hexadecimal
literals was used by both String and Char literal parsers. This caused
a bug that prevented PureScript source code from having string literals
containing UTF-8 hexadecimal literals representing code units larger
than two bytes.

Closes #48.