### PR TITLE
Properly visit types and expressions that are part of application spine

### DIFF
--- a/src/PureScript/CST/Traversal.purs
+++ b/src/PureScript/CST/Traversal.purs
@@ -351,8 +351,8 @@ traverseExprAppSpine
   => { | OnBinder (Rewrite e f) + OnExpr (Rewrite e f) + OnType (Rewrite e f) + r }
   -> Rewrite e f (AppSpine Expr)
 traverseExprAppSpine k = case _ of
-  AppType tok ty -> AppType tok <$> traverseType k ty
-  AppTerm expr -> AppTerm <$> traverseExpr k expr
+  AppType tok ty -> AppType tok <$> k.onType ty
+  AppTerm expr -> AppTerm <$> k.onExpr expr
 
 traverseDelimited
   :: forall f a


### PR DESCRIPTION
I discovered this issue after noticing that some expressions don't get traversed properly.

Turns out, the spine traversal delegates directly to `traverseType` and `traverseExpr` instead of `k.onType` and `k.onExpr` respectively, so that the visitor never sees expressions that are function application parameters.