### PR TITLE
Add attached derive clause support

### DIFF
--- a/spago.lock
+++ b/spago.lock
@@ -44,74 +44,10 @@
             {
               "prelude": ">=6.0.2 <7.0.0"
             }
-          ],
-          "build_plan": [
-            "aff",
-            "arraybuffer-types",
-            "arrays",
-            "bifunctors",
-            "catenable-lists",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "language-cst-parser",
-            "lazy",
-            "lists",
-            "maybe",
-            "minibench",
-            "newtype",
-            "node-buffer",
-            "node-event-emitter",
-            "node-fs",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         },
         "test": {
-          "dependencies": [],
-          "build_plan": []
+          "dependencies": []
         }
       },
       "language-cst-parser": {
@@ -196,50 +132,6 @@
             {
               "unsafe-coerce": ">=6.0.0 <7.0.0"
             }
-          ],
-          "build_plan": [
-            "arrays",
-            "bifunctors",
-            "catenable-lists",
-            "const",
-            "contravariant",
-            "control",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "nonempty",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "partial",
-            "prelude",
-            "profunctor",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         },
         "test": {
@@ -247,61 +139,6 @@
             "console",
             "effect",
             "node-process"
-          ],
-          "build_plan": [
-            "aff",
-            "arraybuffer-types",
-            "arrays",
-            "bifunctors",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "node-buffer",
-            "node-event-emitter",
-            "node-process",
-            "node-streams",
-            "nonempty",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         }
       },
@@ -390,81 +227,10 @@
             {
               "strings": ">=6.0.1 <7.0.0"
             }
-          ],
-          "build_plan": [
-            "aff",
-            "argonaut-codecs",
-            "argonaut-core",
-            "arraybuffer-types",
-            "arrays",
-            "avar",
-            "bifunctors",
-            "catenable-lists",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "filterable",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "language-cst-parser",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "node-buffer",
-            "node-child-process",
-            "node-event-emitter",
-            "node-fs",
-            "node-glob-basic",
-            "node-os",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "record",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         },
         "test": {
-          "dependencies": [],
-          "build_plan": []
+          "dependencies": []
         }
       }
     },
@@ -474,21 +240,19 @@
     "aff": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-5MmdI4+0RHBtSBy+YlU3/Cq4R5W2ih3OaRedJIrVHdk=",
+      "integrity": "sha256-9BRIrSdRoYybfiUmBqgKJ66cPqxYHb277bVWQMn/9sg=",
       "dependencies": [
-        "bifunctors",
         "control",
         "datetime",
         "effect",
         "either",
         "exceptions",
-        "foldable-traversable",
         "functions",
-        "maybe",
         "newtype",
         "parallel",
+        "partial",
         "prelude",
-        "refs",
+        "st",
         "tailrec",
         "transformers",
         "unsafe-coerce"
@@ -497,25 +261,30 @@
     "argonaut-codecs": {
       "type": "registry",
       "version": "9.1.0",
-      "integrity": "sha256-N6efXByUeg848ompEqJfVvZuZPfdRYDGlTDFn0G0Oh8=",
+      "integrity": "sha256-K910SBrmYallESsm8pxJYThs7lig6hxX3M4PW33Cgew=",
       "dependencies": [
         "argonaut-core",
         "arrays",
-        "effect",
+        "bifunctors",
+        "either",
+        "foldable-traversable",
         "foreign-object",
         "identity",
         "integers",
+        "lists",
         "maybe",
         "nonempty",
         "ordered-collections",
         "prelude",
-        "record"
+        "record",
+        "strings",
+        "tuples"
       ]
     },
     "argonaut-core": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=",
+      "integrity": "sha256-gYZihtBIKthVuXXoiPphMookSf8M5aHyFYkcIWqlxTM=",
       "dependencies": [
         "arrays",
         "control",
@@ -533,13 +302,13 @@
     "arraybuffer-types": {
       "type": "registry",
       "version": "3.0.2",
-      "integrity": "sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=",
+      "integrity": "sha256-p05cJnSkyeoB7VHzMyc2Eb1RwUaB7Nl0sQSqEGNEUD8=",
       "dependencies": []
     },
     "arrays": {
       "type": "registry",
       "version": "7.3.0",
-      "integrity": "sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=",
+      "integrity": "sha256-GD4z7LCi9wzi7FCQqbWhvs8paoUK9NO+HwgXZ+KP8Rk=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -560,20 +329,21 @@
     "avar": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-f+bRR3qQPa/GVe4UbLQiJBy7+PzJkUCwT6qNn0UlkMY=",
+      "integrity": "sha256-8V4SxF4TIWZ9Ik1P4lPzIRUAZeFBe8w5WA2VcCEKsIk=",
       "dependencies": [
         "aff",
         "effect",
         "either",
         "exceptions",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "bifunctors": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-6enQzl1vqnFTQZ1WX9BnoOOVdPGO9WZvVXldHckVQvY=",
+      "integrity": "sha256-CvZRb8uI75eKIqiYntR+k05Wk6tKlMS5w8sCA2AFna0=",
       "dependencies": [
         "const",
         "either",
@@ -585,7 +355,7 @@
     "catenable-lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=",
+      "integrity": "sha256-7+i/MHBLIRh604iCNT4ENWRWE/wuHIotER4kpdX9Ve0=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -599,7 +369,7 @@
     "console": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=",
+      "integrity": "sha256-3T5PPz1mATZmV0C4GzkCkpLlCa5xG7u8ZNgnLrrrI1Q=",
       "dependencies": [
         "effect",
         "prelude"
@@ -608,7 +378,7 @@
     "const": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=",
+      "integrity": "sha256-S+m0lQsxnji0z1XRUmkn+3RFuWJ5CXWuIr1u3i8Bfoc=",
       "dependencies": [
         "invariant",
         "newtype",
@@ -618,7 +388,7 @@
     "contravariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=",
+      "integrity": "sha256-nuckEWqL80NaPmR/l9AUyrfycNh18XcvlZV9PAamwqc=",
       "dependencies": [
         "const",
         "either",
@@ -630,7 +400,7 @@
     "control": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=",
+      "integrity": "sha256-0vxyYh5FL+ilxgLo954w1LqCUC0RSIivNNlb9CaNUQg=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -639,7 +409,7 @@
     "datetime": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=",
+      "integrity": "sha256-tbv6eDXy6QOD7YSknxYSbsDF32OC2JrNbSBpzMs7Doc=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -662,7 +432,7 @@
     "distributive": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=",
+      "integrity": "sha256-netyJK4B32PDYHD0tF2AenKgo3urzbI770ycM0pArAo=",
       "dependencies": [
         "identity",
         "newtype",
@@ -674,7 +444,7 @@
     "effect": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=",
+      "integrity": "sha256-DdqU3bncRTjgMVPPRlAuGHVeajSPEcRaRhNuio7if6s=",
       "dependencies": [
         "prelude"
       ]
@@ -682,7 +452,7 @@
     "either": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=",
+      "integrity": "sha256-tBHx3PgtH4GZOApZCDkcM7szRTYJinrUrVGWazQCUUg=",
       "dependencies": [
         "control",
         "invariant",
@@ -693,7 +463,7 @@
     "enums": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=",
+      "integrity": "sha256-sdZOmLX5+5pASGpvVyT0vSD5BBYQjZiayjV5XiPutso=",
       "dependencies": [
         "control",
         "either",
@@ -710,7 +480,7 @@
     "exceptions": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-K0T89IHtF3vBY7eSAO7eDOqSb2J9kZGAcDN5+IKsF8E=",
+      "integrity": "sha256-nRrr+N0wk0TUFOWLR7e1n1oxcXo/X345bQUtoY9lW6A=",
       "dependencies": [
         "effect",
         "either",
@@ -721,7 +491,7 @@
     "exists": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=",
+      "integrity": "sha256-vtLbrWNaI+pzx/2fw2AQnCovoLtcosClIhjO26QKkh8=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -729,20 +499,26 @@
     "filterable": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-cCojJHRnTmpY1j1kegI4CFwghdQ2Fm/8dzM8IlC+lng=",
+      "integrity": "sha256-be7ci1Bzwud2waqoCtNGsTBZbt7fi+gCLvGddQQRJ3A=",
       "dependencies": [
         "arrays",
+        "control",
         "either",
         "foldable-traversable",
         "identity",
         "lists",
-        "ordered-collections"
+        "maybe",
+        "newtype",
+        "ordered-collections",
+        "prelude",
+        "st",
+        "tuples"
       ]
     },
     "foldable-traversable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=",
+      "integrity": "sha256-NGGWyCio/xjce6fPP7y3wwg7CheqllID6aJudDxbWhA=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -760,23 +536,23 @@
     "foreign": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=",
+      "integrity": "sha256-jiDRMVQfovGsbbA/FzbzYf6iWk9i2b5gNrIjz+gFfsI=",
       "dependencies": [
         "either",
         "functions",
-        "identity",
         "integers",
         "lists",
         "maybe",
         "prelude",
         "strings",
-        "transformers"
+        "transformers",
+        "unsafe-coerce"
       ]
     },
     "foreign-object": {
       "type": "registry",
       "version": "4.1.0",
-      "integrity": "sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=",
+      "integrity": "sha256-x/Q7r80z/vmHRKvPwhYmHP/DnJciPtsyGfRTMzayKIU=",
       "dependencies": [
         "arrays",
         "foldable-traversable",
@@ -789,13 +565,14 @@
         "tailrec",
         "tuples",
         "typelevel-prelude",
-        "unfoldable"
+        "unfoldable",
+        "unsafe-coerce"
       ]
     },
     "free": {
       "type": "registry",
       "version": "7.1.0",
-      "integrity": "sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=",
+      "integrity": "sha256-tUBInfUpRQEw4u94GWcYW7EYdmSdDHSRn88a+C0eltU=",
       "dependencies": [
         "catenable-lists",
         "control",
@@ -816,7 +593,7 @@
     "functions": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=",
+      "integrity": "sha256-0jgtOr+SFO4UScKc40oA/9Vdcf2rLn3h3vZlY0KfqVo=",
       "dependencies": [
         "prelude"
       ]
@@ -824,7 +601,7 @@
     "functors": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=",
+      "integrity": "sha256-W1o/4wcp6S3chodYL8uixlXK2mfr1L+SzM1R+whqUco=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -844,7 +621,7 @@
     "gen": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=",
+      "integrity": "sha256-kyOateeOtQa07vfTMYeSuCKdelgKE1R65fwKkZ10wsY=",
       "dependencies": [
         "either",
         "foldable-traversable",
@@ -861,7 +638,7 @@
     "identity": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=",
+      "integrity": "sha256-RY/iXPpxpqvKHYfJeFVNI1J06kohB9rbtWYuha8t0LE=",
       "dependencies": [
         "control",
         "invariant",
@@ -872,7 +649,7 @@
     "integers": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=",
+      "integrity": "sha256-Y8yozC1uHRLcruobEyv5/bMKzE1BoKJ/olHv6o+bgm8=",
       "dependencies": [
         "maybe",
         "numbers",
@@ -882,7 +659,7 @@
     "invariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=",
+      "integrity": "sha256-HyoT1I5qIHRq8RSZji6zZDvqnpVjLw748utrKwZtqsw=",
       "dependencies": [
         "control",
         "prelude"
@@ -891,20 +668,22 @@
     "js-date": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=",
+      "integrity": "sha256-DNQrp4xYc8o80jtxo0aOkUeXGi6h0Xidkk2ZQ8Y4l5Y=",
       "dependencies": [
         "datetime",
         "effect",
-        "exceptions",
+        "enums",
         "foreign",
+        "functions",
         "integers",
-        "now"
+        "maybe",
+        "prelude"
       ]
     },
     "lazy": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=",
+      "integrity": "sha256-MHRC+1Pc+AjortBp4b/e1e6KpEpsDwaJBNBB7TOL+1I=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -915,7 +694,7 @@
     "lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=",
+      "integrity": "sha256-/mGd7wLoU+wsTcqii7SSUByxsvwvjnu2PjwAD47yYb4=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -934,7 +713,7 @@
     "maybe": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=",
+      "integrity": "sha256-8X6XEgtZ5lqfkEuc1hWOofnL6mwhk8gSJTxwvbR/SbY=",
       "dependencies": [
         "control",
         "invariant",
@@ -945,13 +724,12 @@
     "minibench": {
       "type": "registry",
       "version": "4.0.1",
-      "integrity": "sha256-7jyxcklZI49q/otYvMV4f9YnJwEqQ3Me5buhDwAOydw=",
+      "integrity": "sha256-zd/YnOqnzz/ers1umv5rgJOyPntF2zFpcLVbPWQIbYU=",
       "dependencies": [
         "console",
         "effect",
         "integers",
         "numbers",
-        "partial",
         "prelude",
         "refs"
       ]
@@ -959,7 +737,7 @@
     "newtype": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=",
+      "integrity": "sha256-dt6w0cty4OS+Pjt9fsh3iU6ottqSU83mdAZkaEEvo6c=",
       "dependencies": [
         "prelude",
         "safe-coerce"
@@ -968,12 +746,15 @@
     "node-buffer": {
       "type": "registry",
       "version": "9.0.0",
-      "integrity": "sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=",
+      "integrity": "sha256-RdQjilmEHqsT4fwpCr8Mavw8KTafYrS3ZM6zeAAVAl8=",
       "dependencies": [
         "arraybuffer-types",
         "effect",
+        "functions",
         "maybe",
         "nullable",
+        "partial",
+        "prelude",
         "st",
         "unsafe-coerce"
       ]
@@ -981,25 +762,36 @@
     "node-child-process": {
       "type": "registry",
       "version": "11.1.0",
-      "integrity": "sha256-vioMNgk8p+CGwlb6T3I3TIir27el85Yg4satLE/I89w=",
+      "integrity": "sha256-Um7g75gXKEX51ZlviJWocTjUENUW1qHgqGqhYKkka74=",
       "dependencies": [
+        "aff",
+        "datetime",
+        "effect",
+        "either",
         "exceptions",
         "foreign",
         "foreign-object",
         "functions",
+        "maybe",
+        "node-buffer",
         "node-event-emitter",
         "node-fs",
         "node-os",
         "node-streams",
         "nullable",
+        "parallel",
+        "partial",
         "posix-types",
+        "prelude",
+        "refs",
+        "safe-coerce",
         "unsafe-coerce"
       ]
     },
     "node-event-emitter": {
       "type": "registry",
       "version": "3.0.0",
-      "integrity": "sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=",
+      "integrity": "sha256-wodx71NxJBPXOaawFn01V1ByYB2vT+I3RuV2giOVKMg=",
       "dependencies": [
         "effect",
         "either",
@@ -1013,8 +805,9 @@
     "node-fs": {
       "type": "registry",
       "version": "9.2.0",
-      "integrity": "sha256-Sg0vkXycEzkEerX6hLccz21Ygd9w1+QSk1thotRZPGI=",
+      "integrity": "sha256-fxioTSm9y47WuYs9F/7nxCh/RVDCl3Kr3Hg779J4SJA=",
       "dependencies": [
+        "aff",
         "datetime",
         "effect",
         "either",
@@ -1030,14 +823,13 @@
         "nullable",
         "partial",
         "prelude",
-        "strings",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-glob-basic": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-COPsHFpqwFGOBbo3DZ4yQLp5UTNshLcINIV2P3h8g6o=",
+      "integrity": "sha256-bGqHSBqz99RgUAuoFEllfm5dIlNBGV6x1QSXbQhsbLk=",
       "dependencies": [
         "aff",
         "effect",
@@ -1059,17 +851,15 @@
     "node-os": {
       "type": "registry",
       "version": "5.1.0",
-      "integrity": "sha256-K3gcu9AXanN1+qtk1900+Fi+CuO0s3/H/RMNRNgIzso=",
+      "integrity": "sha256-UtQiPiZy5ouV832ubww/U8KlpVYny9xsW8WWfYOEgtA=",
       "dependencies": [
         "arrays",
         "bifunctors",
-        "console",
         "control",
         "datetime",
         "effect",
         "either",
         "exceptions",
-        "foldable-traversable",
         "foreign",
         "foreign-object",
         "functions",
@@ -1085,7 +875,7 @@
     "node-path": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-ePOElFamHkffhwJcS0Ozq4A14rflnkasFU6X2B8/yXs=",
+      "integrity": "sha256-j7n/SmpVz0FOMJl4XZop3ofJ+MeIPkMNqUEUKHEL6Us=",
       "dependencies": [
         "effect"
       ]
@@ -1093,23 +883,25 @@
     "node-process": {
       "type": "registry",
       "version": "11.2.0",
-      "integrity": "sha256-+2MQDYChjGbVbapCyJtuWYwD41jk+BntF/kcOTKBMVs=",
+      "integrity": "sha256-onzKeNmaeYfN3HSDPqSFTrrP2Yl9tnVsfKKhnf2plxM=",
       "dependencies": [
         "effect",
+        "exceptions",
         "foreign",
         "foreign-object",
         "maybe",
         "node-event-emitter",
         "node-streams",
+        "nullable",
         "posix-types",
         "prelude",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-streams": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-7RJ6RqjOlhW+QlDFQNUHlkCG/CuYTTLT8yary5jhhsU=",
+      "integrity": "sha256-yuVGm/R/tBr4Nphi+a1a984Z0fkmN9Q5wWtSmbmJTpA=",
       "dependencies": [
         "aff",
         "arrays",
@@ -1130,7 +922,7 @@
     "nonempty": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=",
+      "integrity": "sha256-Ctkq8/+KiGqCE53Y/LvibA/coy7ev9HtRZU+GYS7yfQ=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -1140,47 +932,42 @@
         "unfoldable"
       ]
     },
-    "now": {
-      "type": "registry",
-      "version": "6.0.0",
-      "integrity": "sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=",
-      "dependencies": [
-        "datetime",
-        "effect"
-      ]
-    },
     "nullable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=",
+      "integrity": "sha256-CDAZk+L9Sc0GCFTkE8n+qdp4Ys8avvnkU+m2hVALt7M=",
       "dependencies": [
-        "effect",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "numbers": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=",
+      "integrity": "sha256-ZydYckgwRAnRaFC7pu6fADhzdwX+UqHZrfJyet64zls=",
       "dependencies": [
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "ordered-collections": {
       "type": "registry",
       "version": "3.2.0",
-      "integrity": "sha256-o9jqsj5rpJmMdoe/zyufWHFjYYFTTsJpgcuCnqCO6PM=",
+      "integrity": "sha256-NaEXc2cz/7lJfxPWEja4XlZbGxuRqJwFKQJjsJf51kQ=",
       "dependencies": [
         "arrays",
+        "control",
         "foldable-traversable",
+        "functions",
         "gen",
         "lists",
         "maybe",
+        "newtype",
         "partial",
         "prelude",
-        "st",
+        "safe-coerce",
         "tailrec",
         "tuples",
         "unfoldable"
@@ -1189,7 +976,7 @@
     "orders": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=",
+      "integrity": "sha256-nSMxZK7wxyDULkjZqvMyB71mVo6b0AyLLHosDVbv1XM=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -1198,7 +985,7 @@
     "parallel": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=",
+      "integrity": "sha256-bAGpVhrFz2IyHkA4MR7+tE/19FZ7dzYBdYPgK5svkqw=",
       "dependencies": [
         "control",
         "effect",
@@ -1216,28 +1003,29 @@
     "partial": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=",
+      "integrity": "sha256-mdrlJBAgFMh79hNRW39uv7c+BwnnaOrAMmdh7+VhEhs=",
       "dependencies": []
     },
     "posix-types": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-ZfFz8RR1lee/o/Prccyeut3Q+9tYd08mlR72sIh6GzA=",
+      "integrity": "sha256-Je5jG439F/SFO/IvVevZnWVxDIonrehlKuJkefP2lHE=",
       "dependencies": [
         "maybe",
+        "newtype",
         "prelude"
       ]
     },
     "prelude": {
       "type": "registry",
       "version": "6.0.2",
-      "integrity": "sha256-kiAPZxihtAel8uRiTNdccf4qylp/9J3jNkEHNAD0MsE=",
+      "integrity": "sha256-IqykrDRquGUD/LRSad7y75hZv3bUsGQ4knc8tdez8Qw=",
       "dependencies": []
     },
     "profunctor": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-E58hSYdJvF2Qjf9dnWLPlJKh2Z2fLfFLkQoYi16vsFk=",
+      "integrity": "sha256-Ow0mJC+PIIRq/a3mzCWY5vxuTgR/e+Ee68+mWeSRnWY=",
       "dependencies": [
         "control",
         "distributive",
@@ -1252,7 +1040,7 @@
     "record": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=",
+      "integrity": "sha256-WQ8fqp4X1wTA70J4qUcPW4Z7DCwx6e5KJnT/EuTdWSc=",
       "dependencies": [
         "functions",
         "prelude",
@@ -1262,7 +1050,7 @@
     "refs": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=",
+      "integrity": "sha256-KKD5G9dR2SauuDGULUJsxjqDOEi1Jqm+2Sq5U2mY8YU=",
       "dependencies": [
         "effect",
         "prelude"
@@ -1271,7 +1059,7 @@
     "safe-coerce": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=",
+      "integrity": "sha256-EJrxtKt5xC7TYjBZrSBO/J7Aw3DmtilYjt4olpAXWVc=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -1279,8 +1067,9 @@
     "st": {
       "type": "registry",
       "version": "6.2.0",
-      "integrity": "sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=",
+      "integrity": "sha256-WI4MEkkwUd4pnwZQ3G8VKWgX5t1RSNJludm5e9boaRo=",
       "dependencies": [
+        "effect",
         "partial",
         "prelude",
         "tailrec",
@@ -1290,7 +1079,7 @@
     "strings": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=",
+      "integrity": "sha256-FNto2hoNW5Da6W6crIk77YXMagBvOGHZE1kO7eZ1vLM=",
       "dependencies": [
         "arrays",
         "control",
@@ -1313,7 +1102,7 @@
     "tailrec": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=",
+      "integrity": "sha256-xrorCfP0xV1wubs27idQCHQqdvSUuqmmL/am7Ji1wVU=",
       "dependencies": [
         "bifunctors",
         "effect",
@@ -1328,7 +1117,7 @@
     "transformers": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-3Bm+Z6tsC/paG888XkywDngJ2JMos+JfOhRlkVfb7gI=",
+      "integrity": "sha256-QJmgNT/y7ljPHSsXaW4zxF/982BFiQ90KNL1g/NtEOQ=",
       "dependencies": [
         "control",
         "distributive",
@@ -1350,7 +1139,7 @@
     "tuples": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=",
+      "integrity": "sha256-BKy7EfK8S1KeTCwyWqyW1wwcpSAQuh3IsczSVgS6fzY=",
       "dependencies": [
         "control",
         "invariant",
@@ -1360,13 +1149,13 @@
     "type-equality": {
       "type": "registry",
       "version": "4.0.1",
-      "integrity": "sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=",
+      "integrity": "sha256-BBqYOSnAKmayRvR5mtZoCf4SlYs2ipatD/+5nQx73aw=",
       "dependencies": []
     },
     "typelevel-prelude": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=",
+      "integrity": "sha256-+pHi14/40mTj/+lmCWqL0T7iXIXD1+NSg/KItyyoB0A=",
       "dependencies": [
         "prelude",
         "type-equality"
@@ -1375,7 +1164,7 @@
     "unfoldable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=",
+      "integrity": "sha256-BK/6By1sKp/ztk+9CF3q43SV0QDTLVdsGqFerKHSmbg=",
       "dependencies": [
         "foldable-traversable",
         "maybe",
@@ -1387,7 +1176,7 @@
     "unsafe-coerce": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=",
+      "integrity": "sha256-0L1QsaY20OILjfU5TV72d3U/tSjhmL9hJ32WMp857Lk=",
       "dependencies": []
     }
   }

--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -28,7 +28,7 @@ import PureScript.CST.Errors (ParseError(..), RecoveredError(..))
 import PureScript.CST.Parser.Monad (Parser, eof, lookAhead, many, optional, recover, take, try)
 import PureScript.CST.TokenStream (TokenStep(..), TokenStream, currentIndentColumn)
 import PureScript.CST.TokenStream as TokenStream
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), Delimited, DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), Fixity(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), IntValue(..), Label(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), ModuleName(..), Name(..), OneOrDelimited(..), Operator(..), PatternGuard(..), Prefixed(..), Proper(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Role(..), Row(..), Separated(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), Delimited, DeriveClassHead(..), DeriveClause(..), DoStatement(..), Export(..), Expr(..), Fixity(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), IntValue(..), Label(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), ModuleName(..), Name(..), OneOrDelimited(..), Operator(..), PatternGuard(..), Prefixed(..), Proper(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Role(..), Row(..), Separated(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
 
 type Recovered :: (P.Type -> P.Type) -> P.Type
 type Recovered f = f RecoveredError
@@ -192,7 +192,7 @@ parseDeclData1 :: SourceToken -> Name Proper -> Parser (Recovered Declaration)
 parseDeclData1 keyword name = do
   vars <- many parseTypeVarBindingPlain
   ctors <- optional (Tuple <$> tokEquals <*> separated tokPipe parseDataCtor)
-  derivs <- many parseDerivingClause
+  derivs <- many parseDeriveClause
   pure $ DeclData { keyword, name, vars } ctors derivs
 
 parseDataCtor :: Parser (Recovered DataCtor)
@@ -214,7 +214,7 @@ parseDeclNewtype1 keyword name = do
   tok <- tokEquals
   wrapper <- parseProper
   body <- parseTypeAtom
-  derivs <- many parseDerivingClause
+  derivs <- many parseDeriveClause
   pure $ DeclNewtype { keyword, name, vars } tok wrapper body derivs
 
 parseDeclType :: Parser (Recovered Declaration)
@@ -340,33 +340,33 @@ parseDeclDerive = do
   types <- many parseTypeAtom
   pure $ DeclDerive derive_ newtype_ { keyword, name, constraints, className, types }
 
-parseDerivingClause :: Parser (Recovered DerivingClause)
-parseDerivingClause = do
+parseDeriveClause :: Parser (Recovered DeriveClause)
+parseDeriveClause = do
   derive_ <- tokKeyword "derive"
-  parseDerivingClauseNewtype derive_
-    <|> parseDerivingClauseStandardOrVia derive_
+  parseDeriveClauseNewtype derive_
+    <|> parseDeriveClauseStandardOrVia derive_
 
-parseDerivingClauseNewtype :: SourceToken -> Parser (Recovered DerivingClause)
-parseDerivingClauseNewtype derive_ = do
+parseDeriveClauseNewtype :: SourceToken -> Parser (Recovered DeriveClause)
+parseDeriveClauseNewtype derive_ = do
   newtype_ <- tokKeyword "newtype"
-  classes <- parens (separated tokComma parseDerivingClassHead)
-  pure $ DerivingClauseNewtype derive_ newtype_ classes
+  classes <- parens (separated tokComma parseDeriveClassHead)
+  pure $ DeriveClauseNewtype derive_ newtype_ classes
 
-parseDerivingClauseStandardOrVia :: SourceToken -> Parser (Recovered DerivingClause)
-parseDerivingClauseStandardOrVia derive_ = do
-  classes <- parens (separated tokComma parseDerivingClassHead)
+parseDeriveClauseStandardOrVia :: SourceToken -> Parser (Recovered DeriveClause)
+parseDeriveClauseStandardOrVia derive_ = do
+  classes <- parens (separated tokComma parseDeriveClassHead)
   via <- optional $ try $ Tuple <$> tokKeyword "via" <*> parseTypeAtom
   case via of
     Just (Tuple viaTok viaTy) ->
-      pure $ DerivingClauseVia derive_ classes viaTok viaTy
+      pure $ DeriveClauseVia derive_ classes viaTok viaTy
     Nothing ->
-      pure $ DerivingClauseStandard derive_ classes
+      pure $ DeriveClauseStandard derive_ classes
 
-parseDerivingClassHead :: Parser (Recovered DerivingClassHead)
-parseDerivingClassHead = do
+parseDeriveClassHead :: Parser (Recovered DeriveClassHead)
+parseDeriveClassHead = do
   className <- parseQualifiedProper
   args <- many parseTypeAtom
-  pure $ DerivingClassHead { className, args }
+  pure $ DeriveClassHead { className, args }
 
 parseDeclValue :: Parser (Recovered Declaration)
 parseDeclValue = do

--- a/src/PureScript/CST/Parser.purs
+++ b/src/PureScript/CST/Parser.purs
@@ -28,7 +28,7 @@ import PureScript.CST.Errors (ParseError(..), RecoveredError(..))
 import PureScript.CST.Parser.Monad (Parser, eof, lookAhead, many, optional, recover, take, try)
 import PureScript.CST.TokenStream (TokenStep(..), TokenStream, currentIndentColumn)
 import PureScript.CST.TokenStream as TokenStream
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), Delimited, DoStatement(..), Export(..), Expr(..), Fixity(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), IntValue(..), Label(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), ModuleName(..), Name(..), OneOrDelimited(..), Operator(..), PatternGuard(..), Prefixed(..), Proper(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Role(..), Row(..), Separated(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), Delimited, DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), Fixity(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), IntValue(..), Label(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), ModuleName(..), Name(..), OneOrDelimited(..), Operator(..), PatternGuard(..), Prefixed(..), Proper(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Role(..), Row(..), Separated(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
 
 type Recovered :: (P.Type -> P.Type) -> P.Type
 type Recovered f = f RecoveredError
@@ -192,7 +192,8 @@ parseDeclData1 :: SourceToken -> Name Proper -> Parser (Recovered Declaration)
 parseDeclData1 keyword name = do
   vars <- many parseTypeVarBindingPlain
   ctors <- optional (Tuple <$> tokEquals <*> separated tokPipe parseDataCtor)
-  pure $ DeclData { keyword, name, vars } ctors
+  derivs <- many parseDerivingClause
+  pure $ DeclData { keyword, name, vars } ctors derivs
 
 parseDataCtor :: Parser (Recovered DataCtor)
 parseDataCtor = ado
@@ -213,7 +214,8 @@ parseDeclNewtype1 keyword name = do
   tok <- tokEquals
   wrapper <- parseProper
   body <- parseTypeAtom
-  pure $ DeclNewtype { keyword, name, vars } tok wrapper body
+  derivs <- many parseDerivingClause
+  pure $ DeclNewtype { keyword, name, vars } tok wrapper body derivs
 
 parseDeclType :: Parser (Recovered Declaration)
 parseDeclType = do
@@ -337,6 +339,34 @@ parseDeclDerive = do
   className <- parseQualifiedProper
   types <- many parseTypeAtom
   pure $ DeclDerive derive_ newtype_ { keyword, name, constraints, className, types }
+
+parseDerivingClause :: Parser (Recovered DerivingClause)
+parseDerivingClause = do
+  derive_ <- tokKeyword "derive"
+  parseDerivingClauseNewtype derive_
+    <|> parseDerivingClauseStandardOrVia derive_
+
+parseDerivingClauseNewtype :: SourceToken -> Parser (Recovered DerivingClause)
+parseDerivingClauseNewtype derive_ = do
+  newtype_ <- tokKeyword "newtype"
+  classes <- parens (separated tokComma parseDerivingClassHead)
+  pure $ DerivingClauseNewtype derive_ newtype_ classes
+
+parseDerivingClauseStandardOrVia :: SourceToken -> Parser (Recovered DerivingClause)
+parseDerivingClauseStandardOrVia derive_ = do
+  classes <- parens (separated tokComma parseDerivingClassHead)
+  via <- optional $ try $ Tuple <$> tokKeyword "via" <*> parseTypeAtom
+  case via of
+    Just (Tuple viaTok viaTy) ->
+      pure $ DerivingClauseVia derive_ classes viaTok viaTy
+    Nothing ->
+      pure $ DerivingClauseStandard derive_ classes
+
+parseDerivingClassHead :: Parser (Recovered DerivingClassHead)
+parseDerivingClassHead = do
+  className <- parseQualifiedProper
+  args <- many parseTypeAtom
+  pure $ DerivingClassHead { className, args }
 
 parseDeclValue :: Parser (Recovered Declaration)
 parseDeclValue = do

--- a/src/PureScript/CST/Range.purs
+++ b/src/PureScript/CST/Range.purs
@@ -18,7 +18,7 @@ import Data.Tuple (Tuple(..), fst, snd)
 import PureScript.CST.Errors (RecoveredError(..))
 import PureScript.CST.Range.TokenList (TokenList, cons, singleton)
 import PureScript.CST.Range.TokenList as TokenList
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), Name(..), OneOrDelimited(..), PatternGuard(..), Prefixed(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceRange, Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), Name(..), OneOrDelimited(..), PatternGuard(..), Prefixed(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceRange, Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
 
 class RangeOf a where
   rangeOf :: a -> SourceRange
@@ -411,19 +411,62 @@ instance tokensOfDataCtor :: TokensOf e => TokensOf (DataCtor e) where
   tokensOf (DataCtor { name, fields }) =
     tokensOf name <> tokensOf fields
 
+instance rangeOfDerivingClassHead :: RangeOf e => RangeOf (DerivingClassHead e) where
+  rangeOf (DerivingClassHead { className, args }) = do
+    let
+      { end } = case Array.last args of
+        Nothing -> rangeOf className
+        Just ty -> rangeOf ty
+    { start: (rangeOf className).start
+    , end
+    }
+
+instance tokensOfDerivingClassHead :: TokensOf e => TokensOf (DerivingClassHead e) where
+  tokensOf (DerivingClassHead { className, args }) =
+    tokensOf className <> tokensOf args
+
+instance rangeOfDerivingClause :: RangeOf e => RangeOf (DerivingClause e) where
+  rangeOf = case _ of
+    DerivingClauseStandard kw classes ->
+      { start: kw.range.start
+      , end: (rangeOf classes).end
+      }
+    DerivingClauseNewtype kw _ classes ->
+      { start: kw.range.start
+      , end: (rangeOf classes).end
+      }
+    DerivingClauseVia kw _ _ viaTy ->
+      { start: kw.range.start
+      , end: (rangeOf viaTy).end
+      }
+
+instance tokensOfDerivingClause :: TokensOf e => TokensOf (DerivingClause e) where
+  tokensOf = case _ of
+    DerivingClauseStandard kw classes ->
+      cons kw $ defer \_ -> tokensOf classes
+    DerivingClauseNewtype kw nt classes ->
+      cons kw $ defer \_ -> singleton nt <> tokensOf classes
+    DerivingClauseVia kw classes viaTok viaTy ->
+      cons kw $ defer \_ ->
+        tokensOf classes
+          <> singleton viaTok
+          <> tokensOf viaTy
+
 instance rangeOfDecl :: RangeOf e => RangeOf (Declaration e) where
   rangeOf = case _ of
-    DeclData { keyword, name, vars } ctors -> do
+    DeclData { keyword, name, vars } ctors derivs -> do
       let
-        { end } = case ctors of
-          Nothing ->
-            case Array.last vars of
-              Nothing ->
-                rangeOf name
-              Just var ->
-                rangeOf var
-          Just (Tuple _ (Separated { head, tail })) ->
-            rangeOf $ maybe head snd $ Array.last tail
+        { end } = case Array.last derivs of
+          Just d -> rangeOf d
+          Nothing -> case ctors of
+            Nothing ->
+              case Array.last vars of
+                Nothing ->
+                  rangeOf name
+                Just var ->
+                  rangeOf var
+            Just (Tuple _ (Separated { head, tail })) ->
+              rangeOf $ maybe head snd $ Array.last tail
       { start: keyword.range.start
       , end
       }
@@ -431,9 +474,11 @@ instance rangeOfDecl :: RangeOf e => RangeOf (Declaration e) where
       { start: keyword.range.start
       , end: (rangeOf ty).end
       }
-    DeclNewtype { keyword } _ _ ty ->
+    DeclNewtype { keyword } _ _ ty derivs ->
       { start: keyword.range.start
-      , end: (rangeOf ty).end
+      , end: case Array.last derivs of
+          Just d -> (rangeOf d).end
+          Nothing -> (rangeOf ty).end
       }
     DeclClass { keyword, name, vars, fundeps } members -> do
       let
@@ -492,24 +537,26 @@ instance rangeOfDecl :: RangeOf e => RangeOf (Declaration e) where
 
 instance tokensOfDecl :: TokensOf e => TokensOf (Declaration e) where
   tokensOf = case _ of
-    DeclData { keyword, name, vars } ctors ->
+    DeclData { keyword, name, vars } ctors derivs ->
       cons keyword $ defer \_ ->
         tokensOf name
           <> tokensOf vars
           <> foldMap (\(Tuple t cs) -> cons t $ tokensOf cs) ctors
+          <> tokensOf derivs
     DeclType { keyword, name, vars } tok ty ->
       cons keyword $ defer \_ ->
         tokensOf name
           <> tokensOf vars
           <> singleton tok
           <> tokensOf ty
-    DeclNewtype { keyword, name, vars } tok n ty ->
+    DeclNewtype { keyword, name, vars } tok n ty derivs ->
       cons keyword $ defer \_ ->
         tokensOf name
           <> tokensOf vars
           <> singleton tok
           <> tokensOf n
           <> tokensOf ty
+          <> tokensOf derivs
     DeclClass { keyword, super, name, vars, fundeps } members ->
       cons keyword $ defer \_ ->
         foldMap (\(Tuple cs t) -> tokensOf cs <> singleton t) super

--- a/src/PureScript/CST/Range.purs
+++ b/src/PureScript/CST/Range.purs
@@ -18,7 +18,7 @@ import Data.Tuple (Tuple(..), fst, snd)
 import PureScript.CST.Errors (RecoveredError(..))
 import PureScript.CST.Range.TokenList (TokenList, cons, singleton)
 import PureScript.CST.Range.TokenList as TokenList
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), Name(..), OneOrDelimited(..), PatternGuard(..), Prefixed(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceRange, Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), DataCtor(..), DataMembers(..), Declaration(..), DeriveClassHead(..), DeriveClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), Labeled(..), LetBinding(..), Module(..), ModuleBody(..), ModuleHeader(..), Name(..), OneOrDelimited(..), PatternGuard(..), Prefixed(..), QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceRange, Type(..), TypeVarBinding(..), Where(..), Wrapped(..))
 
 class RangeOf a where
   rangeOf :: a -> SourceRange
@@ -411,8 +411,8 @@ instance tokensOfDataCtor :: TokensOf e => TokensOf (DataCtor e) where
   tokensOf (DataCtor { name, fields }) =
     tokensOf name <> tokensOf fields
 
-instance rangeOfDerivingClassHead :: RangeOf e => RangeOf (DerivingClassHead e) where
-  rangeOf (DerivingClassHead { className, args }) = do
+instance rangeOfDeriveClassHead :: RangeOf e => RangeOf (DeriveClassHead e) where
+  rangeOf (DeriveClassHead { className, args }) = do
     let
       { end } = case Array.last args of
         Nothing -> rangeOf className
@@ -421,32 +421,32 @@ instance rangeOfDerivingClassHead :: RangeOf e => RangeOf (DerivingClassHead e) 
     , end
     }
 
-instance tokensOfDerivingClassHead :: TokensOf e => TokensOf (DerivingClassHead e) where
-  tokensOf (DerivingClassHead { className, args }) =
+instance tokensOfDeriveClassHead :: TokensOf e => TokensOf (DeriveClassHead e) where
+  tokensOf (DeriveClassHead { className, args }) =
     tokensOf className <> tokensOf args
 
-instance rangeOfDerivingClause :: RangeOf e => RangeOf (DerivingClause e) where
+instance rangeOfDeriveClause :: RangeOf e => RangeOf (DeriveClause e) where
   rangeOf = case _ of
-    DerivingClauseStandard kw classes ->
+    DeriveClauseStandard kw classes ->
       { start: kw.range.start
       , end: (rangeOf classes).end
       }
-    DerivingClauseNewtype kw _ classes ->
+    DeriveClauseNewtype kw _ classes ->
       { start: kw.range.start
       , end: (rangeOf classes).end
       }
-    DerivingClauseVia kw _ _ viaTy ->
+    DeriveClauseVia kw _ _ viaTy ->
       { start: kw.range.start
       , end: (rangeOf viaTy).end
       }
 
-instance tokensOfDerivingClause :: TokensOf e => TokensOf (DerivingClause e) where
+instance tokensOfDeriveClause :: TokensOf e => TokensOf (DeriveClause e) where
   tokensOf = case _ of
-    DerivingClauseStandard kw classes ->
+    DeriveClauseStandard kw classes ->
       cons kw $ defer \_ -> tokensOf classes
-    DerivingClauseNewtype kw nt classes ->
+    DeriveClauseNewtype kw nt classes ->
       cons kw $ defer \_ -> singleton nt <> tokensOf classes
-    DerivingClauseVia kw classes viaTok viaTy ->
+    DeriveClauseVia kw classes viaTok viaTy ->
       cons kw $ defer \_ ->
         tokensOf classes
           <> singleton viaTok

--- a/src/PureScript/CST/Traversal.purs
+++ b/src/PureScript/CST/Traversal.purs
@@ -50,6 +50,8 @@ module PureScript.CST.Traversal
   , traverseForeign
   , traverseInstance
   , traverseInstanceHead
+  , traverseDerivingClause
+  , traverseDerivingClassHead
   , traverseInstanceBinding
   , traverseClassHead
   , traverseOneOrDelimited
@@ -111,7 +113,7 @@ import Data.Newtype (un)
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..), curry, uncurry)
 import Prim as P
-import PureScript.CST.Types (AdoBlock, AppSpine(..), Binder(..), CaseOf, ClassHead, DataCtor(..), DataHead, Declaration(..), Delimited, DelimitedNonEmpty, DoBlock, DoStatement(..), Expr(..), Foreign(..), Guarded(..), GuardedExpr(..), IfThenElse, Instance(..), InstanceBinding(..), InstanceHead, Labeled(..), Lambda, LetBinding(..), LetIn, Module(..), ModuleBody(..), OneOrDelimited(..), PatternGuard(..), RecordAccessor, RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
+import PureScript.CST.Types (AdoBlock, AppSpine(..), Binder(..), CaseOf, ClassHead, DataCtor(..), DataHead, Declaration(..), Delimited, DelimitedNonEmpty, DerivingClassHead(..), DerivingClause(..), DoBlock, DoStatement(..), Expr(..), Foreign(..), Guarded(..), GuardedExpr(..), IfThenElse, Instance(..), InstanceBinding(..), InstanceHead, Labeled(..), Lambda, LetBinding(..), LetIn, Module(..), ModuleBody(..), OneOrDelimited(..), PatternGuard(..), RecordAccessor, RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
 import Type.Row (type (+))
 
 type Rewrite e f (g :: P.Type -> P.Type) = g e -> f (g e)
@@ -197,9 +199,9 @@ traverseDecl
   => { | OnBinder (Rewrite e f) + OnDecl (Rewrite e f) + OnExpr (Rewrite e f) + OnType (Rewrite e f) + r }
   -> Rewrite e f Declaration
 traverseDecl k = case _ of
-  DeclData binding ctors -> DeclData <$> traverseDataHead k binding <*> traverse (traverse (traverseSeparated (traverseDataCtor k))) ctors
+  DeclData binding ctors derivs -> DeclData <$> traverseDataHead k binding <*> traverse (traverse (traverseSeparated (traverseDataCtor k))) ctors <*> traverse (traverseDerivingClause k) derivs
   DeclType head tok typ -> DeclType <$> traverseDataHead k head <@> tok <*> k.onType typ
-  DeclNewtype head tok name typ -> DeclNewtype <$> traverseDataHead k head <@> tok <@> name <*> k.onType typ
+  DeclNewtype head tok name typ derivs -> DeclNewtype <$> traverseDataHead k head <@> tok <@> name <*> k.onType typ <*> traverse (traverseDerivingClause k) derivs
   DeclClass head sig -> DeclClass <$> traverseClassHead k head <*> traverse (traverse (traverse (traverseLabeled k.onType))) sig
   DeclInstanceChain instances -> DeclInstanceChain <$> traverseSeparated (traverseInstance k) instances
   DeclDerive tok mbTok head -> DeclDerive tok mbTok <$> traverseInstanceHead k head
@@ -238,6 +240,28 @@ traverseInstanceHead k head =
   head { constraints = _, types = _ }
     <$> traverse (ltraverse (traverseOneOrDelimited k.onType)) head.constraints
     <*> traverse k.onType head.types
+
+traverseDerivingClause
+  :: forall e f r
+   . Applicative f
+  => { | OnType (Rewrite e f) + r }
+  -> Rewrite e f DerivingClause
+traverseDerivingClause k = case _ of
+  DerivingClauseStandard tok classes ->
+    DerivingClauseStandard tok <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes
+  DerivingClauseNewtype tok nt classes ->
+    DerivingClauseNewtype tok nt <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes
+  DerivingClauseVia tok classes viaTok viaTy ->
+    DerivingClauseVia tok <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes <@> viaTok <*> k.onType viaTy
+
+traverseDerivingClassHead
+  :: forall e f r
+   . Applicative f
+  => { | OnType (Rewrite e f) + r }
+  -> Rewrite e f DerivingClassHead
+traverseDerivingClassHead k (DerivingClassHead head) =
+  (\args -> DerivingClassHead head { args = args })
+    <$> traverse k.onType head.args
 
 traverseInstanceBinding
   :: forall e f r

--- a/src/PureScript/CST/Traversal.purs
+++ b/src/PureScript/CST/Traversal.purs
@@ -50,8 +50,8 @@ module PureScript.CST.Traversal
   , traverseForeign
   , traverseInstance
   , traverseInstanceHead
-  , traverseDerivingClause
-  , traverseDerivingClassHead
+  , traverseDeriveClause
+  , traverseDeriveClassHead
   , traverseInstanceBinding
   , traverseClassHead
   , traverseOneOrDelimited
@@ -113,7 +113,7 @@ import Data.Newtype (un)
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..), curry, uncurry)
 import Prim as P
-import PureScript.CST.Types (AdoBlock, AppSpine(..), Binder(..), CaseOf, ClassHead, DataCtor(..), DataHead, Declaration(..), Delimited, DelimitedNonEmpty, DerivingClassHead(..), DerivingClause(..), DoBlock, DoStatement(..), Expr(..), Foreign(..), Guarded(..), GuardedExpr(..), IfThenElse, Instance(..), InstanceBinding(..), InstanceHead, Labeled(..), Lambda, LetBinding(..), LetIn, Module(..), ModuleBody(..), OneOrDelimited(..), PatternGuard(..), RecordAccessor, RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
+import PureScript.CST.Types (AdoBlock, AppSpine(..), Binder(..), CaseOf, ClassHead, DataCtor(..), DataHead, Declaration(..), Delimited, DelimitedNonEmpty, DeriveClassHead(..), DeriveClause(..), DoBlock, DoStatement(..), Expr(..), Foreign(..), Guarded(..), GuardedExpr(..), IfThenElse, Instance(..), InstanceBinding(..), InstanceHead, Labeled(..), Lambda, LetBinding(..), LetIn, Module(..), ModuleBody(..), OneOrDelimited(..), PatternGuard(..), RecordAccessor, RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
 import Type.Row (type (+))
 
 type Rewrite e f (g :: P.Type -> P.Type) = g e -> f (g e)
@@ -199,9 +199,9 @@ traverseDecl
   => { | OnBinder (Rewrite e f) + OnDecl (Rewrite e f) + OnExpr (Rewrite e f) + OnType (Rewrite e f) + r }
   -> Rewrite e f Declaration
 traverseDecl k = case _ of
-  DeclData binding ctors derivs -> DeclData <$> traverseDataHead k binding <*> traverse (traverse (traverseSeparated (traverseDataCtor k))) ctors <*> traverse (traverseDerivingClause k) derivs
+  DeclData binding ctors derivs -> DeclData <$> traverseDataHead k binding <*> traverse (traverse (traverseSeparated (traverseDataCtor k))) ctors <*> traverse (traverseDeriveClause k) derivs
   DeclType head tok typ -> DeclType <$> traverseDataHead k head <@> tok <*> k.onType typ
-  DeclNewtype head tok name typ derivs -> DeclNewtype <$> traverseDataHead k head <@> tok <@> name <*> k.onType typ <*> traverse (traverseDerivingClause k) derivs
+  DeclNewtype head tok name typ derivs -> DeclNewtype <$> traverseDataHead k head <@> tok <@> name <*> k.onType typ <*> traverse (traverseDeriveClause k) derivs
   DeclClass head sig -> DeclClass <$> traverseClassHead k head <*> traverse (traverse (traverse (traverseLabeled k.onType))) sig
   DeclInstanceChain instances -> DeclInstanceChain <$> traverseSeparated (traverseInstance k) instances
   DeclDerive tok mbTok head -> DeclDerive tok mbTok <$> traverseInstanceHead k head
@@ -241,26 +241,26 @@ traverseInstanceHead k head =
     <$> traverse (ltraverse (traverseOneOrDelimited k.onType)) head.constraints
     <*> traverse k.onType head.types
 
-traverseDerivingClause
+traverseDeriveClause
   :: forall e f r
    . Applicative f
   => { | OnType (Rewrite e f) + r }
-  -> Rewrite e f DerivingClause
-traverseDerivingClause k = case _ of
-  DerivingClauseStandard tok classes ->
-    DerivingClauseStandard tok <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes
-  DerivingClauseNewtype tok nt classes ->
-    DerivingClauseNewtype tok nt <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes
-  DerivingClauseVia tok classes viaTok viaTy ->
-    DerivingClauseVia tok <$> traverseDelimitedNonEmpty (traverseDerivingClassHead k) classes <@> viaTok <*> k.onType viaTy
+  -> Rewrite e f DeriveClause
+traverseDeriveClause k = case _ of
+  DeriveClauseStandard tok classes ->
+    DeriveClauseStandard tok <$> traverseDelimitedNonEmpty (traverseDeriveClassHead k) classes
+  DeriveClauseNewtype tok nt classes ->
+    DeriveClauseNewtype tok nt <$> traverseDelimitedNonEmpty (traverseDeriveClassHead k) classes
+  DeriveClauseVia tok classes viaTok viaTy ->
+    DeriveClauseVia tok <$> traverseDelimitedNonEmpty (traverseDeriveClassHead k) classes <@> viaTok <*> k.onType viaTy
 
-traverseDerivingClassHead
+traverseDeriveClassHead
   :: forall e f r
    . Applicative f
   => { | OnType (Rewrite e f) + r }
-  -> Rewrite e f DerivingClassHead
-traverseDerivingClassHead k (DerivingClassHead head) =
-  (\args -> DerivingClassHead head { args = args })
+  -> Rewrite e f DeriveClassHead
+traverseDeriveClassHead k (DeriveClassHead head) =
+  (\args -> DeriveClassHead head { args = args })
     <$> traverse k.onType head.args
 
 traverseInstanceBinding

--- a/src/PureScript/CST/Types.purs
+++ b/src/PureScript/CST/Types.purs
@@ -237,9 +237,9 @@ data DataMembers
   | DataEnumerated (Delimited (Name Proper))
 
 data Declaration e
-  = DeclData (DataHead e) (Maybe (Tuple SourceToken (Separated (DataCtor e))))
+  = DeclData (DataHead e) (Maybe (Tuple SourceToken (Separated (DataCtor e)))) (Array (DerivingClause e))
   | DeclType (DataHead e) SourceToken (Type e)
-  | DeclNewtype (DataHead e) SourceToken (Name Proper) (Type e)
+  | DeclNewtype (DataHead e) SourceToken (Name Proper) (Type e) (Array (DerivingClause e))
   | DeclClass (ClassHead e) (Maybe (Tuple SourceToken (NonEmptyArray (Labeled (Name Ident) (Type e)))))
   | DeclInstanceChain (Separated (Instance e))
   | DeclDerive SourceToken (Maybe SourceToken) (InstanceHead e)
@@ -250,6 +250,18 @@ data Declaration e
   | DeclForeign SourceToken SourceToken (Foreign e)
   | DeclRole SourceToken SourceToken (Name Proper) (NonEmptyArray (Tuple SourceToken Role))
   | DeclError e
+
+data DerivingClause e
+  = DerivingClauseStandard SourceToken (DelimitedNonEmpty (DerivingClassHead e))
+  | DerivingClauseNewtype SourceToken SourceToken (DelimitedNonEmpty (DerivingClassHead e))
+  | DerivingClauseVia SourceToken (DelimitedNonEmpty (DerivingClassHead e)) SourceToken (Type e)
+
+newtype DerivingClassHead e = DerivingClassHead
+  { className :: QualifiedName Proper
+  , args :: Array (Type e)
+  }
+
+derive instance newtypeDerivingClassHead :: Newtype (DerivingClassHead e) _
 
 newtype Instance e = Instance
   { head :: InstanceHead e

--- a/src/PureScript/CST/Types.purs
+++ b/src/PureScript/CST/Types.purs
@@ -237,9 +237,9 @@ data DataMembers
   | DataEnumerated (Delimited (Name Proper))
 
 data Declaration e
-  = DeclData (DataHead e) (Maybe (Tuple SourceToken (Separated (DataCtor e)))) (Array (DerivingClause e))
+  = DeclData (DataHead e) (Maybe (Tuple SourceToken (Separated (DataCtor e)))) (Array (DeriveClause e))
   | DeclType (DataHead e) SourceToken (Type e)
-  | DeclNewtype (DataHead e) SourceToken (Name Proper) (Type e) (Array (DerivingClause e))
+  | DeclNewtype (DataHead e) SourceToken (Name Proper) (Type e) (Array (DeriveClause e))
   | DeclClass (ClassHead e) (Maybe (Tuple SourceToken (NonEmptyArray (Labeled (Name Ident) (Type e)))))
   | DeclInstanceChain (Separated (Instance e))
   | DeclDerive SourceToken (Maybe SourceToken) (InstanceHead e)
@@ -251,17 +251,17 @@ data Declaration e
   | DeclRole SourceToken SourceToken (Name Proper) (NonEmptyArray (Tuple SourceToken Role))
   | DeclError e
 
-data DerivingClause e
-  = DerivingClauseStandard SourceToken (DelimitedNonEmpty (DerivingClassHead e))
-  | DerivingClauseNewtype SourceToken SourceToken (DelimitedNonEmpty (DerivingClassHead e))
-  | DerivingClauseVia SourceToken (DelimitedNonEmpty (DerivingClassHead e)) SourceToken (Type e)
+data DeriveClause e
+  = DeriveClauseStandard SourceToken (DelimitedNonEmpty (DeriveClassHead e))
+  | DeriveClauseNewtype SourceToken SourceToken (DelimitedNonEmpty (DeriveClassHead e))
+  | DeriveClauseVia SourceToken (DelimitedNonEmpty (DeriveClassHead e)) SourceToken (Type e)
 
-newtype DerivingClassHead e = DerivingClassHead
+newtype DeriveClassHead e = DeriveClassHead
   { className :: QualifiedName Proper
   , args :: Array (Type e)
   }
 
-derive instance newtypeDerivingClassHead :: Newtype (DerivingClassHead e) _
+derive instance newtypeDeriveClassHead :: Newtype (DeriveClassHead e) _
 
 newtype Instance e = Instance
   { head :: InstanceHead e


### PR DESCRIPTION
> [!WARNING]
> This PR was AI-generated. If that's not okay close it! I'm just trying to make PureScript even nicer

## Summary
- Adds `DeriveClause` and `DeriveClassHead` CST types
- Extends `DeclData` and `DeclNewtype` to carry `Array (DeriveClause e)`
- Adds parser support for `derive (Class)`, `derive newtype (Class)`, and `derive (Class) via Type`
- Adds `RangeOf`/`TokensOf` instances and traversal support

Companion to purescript/purescript#4592